### PR TITLE
add patch to make systemd LoadCredential work again

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -1,0 +1,23 @@
+name: "Update flakes"
+on:
+  repository_dispatch:
+  workflow_dispatch:
+  schedule:
+    - cron:  '38 0 * * 0,4'
+permissions:
+  pull-requests: write
+  contents: write
+jobs:
+  createPullRequest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Nix
+        uses: cachix/install-nix-action@v23
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Update flake.lock
+        uses: DeterminateSystems/update-flake-lock@v20
+        with:
+          pr-labels: |                  # Labels to be set on the PR
+            merge-queue

--- a/examples/default.nix
+++ b/examples/default.nix
@@ -19,28 +19,25 @@ in
     inherit system;
     modules = [
       dummy
-      {
+      ({ pkgs, ... }: {
         services.buildbot-nix.master = {
           enable = true;
           domain = "buildbot2.thalheim.io";
-          workersFile = "/var/lib/secrets/buildbot-nix/workers.json";
+          workersFile = pkgs.writeText "workers.json" ''
+            [
+              { "name": "eve", "pass": "XXXXXXXXXXXXXXXXXXXX", "cores": 16 }
+            ]
+          '';
           github = {
-            tokenFile = "/var/lib/secrets/buildbot-nix/github-token";
-            webhookSecretFile = "/var/lib/secrets/buildbot-nix/github-webhook-secret";
-            oauthSecretFile = "/var/lib/secrets/buildbot-nix/github-oauth-secret";
+            tokenFile = pkgs.writeText "github-token" "ghp_000000000000000000000000000000000000";
+            webhookSecretFile = pkgs.writeText "webhookSecret" "00000000000000000000";
+            oauthSecretFile = pkgs.writeText "oauthSecret" "ffffffffffffffffffffffffffffffffffffffff";
             oauthId = "aaaaaaaaaaaaaaaaaaaa";
             user = "mic92-buildbot";
             admins = [ "Mic92" ];
           };
         };
-        services.nginx.virtualHosts."buildbot2.thalheim.io" = {
-          enableACME = true;
-          forceSSL = true;
-        };
-        networking.firewall.allowedTCPPorts = [ 80 443 ];
-        security.acme.acceptTerms = true;
-        security.acme.defaults.email = "joerg.acme@thalheim.io";
-      }
+      })
       buildbot-nix.nixosModules.buildbot-master
     ];
   };
@@ -48,12 +45,12 @@ in
     inherit system;
     modules = [
       dummy
-      {
+      ({ pkgs, ... }: {
         services.buildbot-nix.worker = {
           enable = true;
-          workerPasswordFile = "/var/lib/secrets/buildbot-nix/worker-password";
+          workerPasswordFile = pkgs.writeText "worker-password-file" "";
         };
-      }
+      })
       buildbot-nix.nixosModules.buildbot-worker
     ];
   };

--- a/flake.lock
+++ b/flake.lock
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1697379843,
-        "narHash": "sha256-RcnGuJgC2K/UpTy+d32piEoBXq2M+nVFzM3ah/ZdJzg=",
+        "lastModified": 1698266953,
+        "narHash": "sha256-jf72t7pC8+8h8fUslUYbWTX5rKsRwOzRMX8jJsGqDXA=",
         "owner": "Nixos",
         "repo": "nixpkgs",
-        "rev": "12bdeb01ff9e2d3917e6a44037ed7df6e6c3df9d",
+        "rev": "75a52265bda7fd25e06e3a67dee3f0354e73243c",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1693611461,
-        "narHash": "sha256-aPODl8vAgGQ0ZYFIRisxYG5MOGSkIczvu2Cd8Gb9+1Y=",
+        "lastModified": 1696343447,
+        "narHash": "sha256-B2xAZKLkkeRFG5XcHHSXXcP7To9Xzr59KXeZiRf4vdQ=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "7f53fdb7bdc5bb237da7fefef12d099e4fd611ca",
+        "rev": "c9afaba3dfa4085dbd2ccb38dfade5141e33d9d4",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1697009197,
-        "narHash": "sha256-viVRhBTFT8fPJTb1N3brQIpFZnttmwo3JVKNuWRVc3s=",
+        "lastModified": 1697379843,
+        "narHash": "sha256-RcnGuJgC2K/UpTy+d32piEoBXq2M+nVFzM3ah/ZdJzg=",
         "owner": "Nixos",
         "repo": "nixpkgs",
-        "rev": "01441e14af5e29c9d27ace398e6dd0b293e25a54",
+        "rev": "12bdeb01ff9e2d3917e6a44037ed7df6e6c3df9d",
         "type": "github"
       },
       "original": {
@@ -50,11 +50,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1695290086,
-        "narHash": "sha256-ol6licpIAzc9oMsEai/9YZhgSMcrnlnD/3ulMLGNKL0=",
+        "lastModified": 1697388351,
+        "narHash": "sha256-63N2eBpKaziIy4R44vjpUu8Nz5fCJY7okKrkixvDQmY=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "e951529be2e7c669487de78f5aef8597bbae5fca",
+        "rev": "aae39f64f5ecbe89792d05eacea5cb241891292a",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
         imports = [
           ./nix/checks/flake-module.nix
         ] ++ inputs.nixpkgs.lib.optional (inputs.treefmt-nix ? flakeModule) ./nix/treefmt/flake-module.nix;
-        systems = [ "x86_64-linux" "aarch64-linux" ];
+        systems = [ "x86_64-linux" ];
         flake = {
           nixosModules.buildbot-master = ./nix/master.nix;
           nixosModules.buildbot-worker = ./nix/worker.nix;

--- a/nix/0001-allow-secrets-to-be-group-readable.patch
+++ b/nix/0001-allow-secrets-to-be-group-readable.patch
@@ -1,0 +1,47 @@
+From 41bd68a23e605fb97b0fccff2af00a39cfd386f3 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?J=C3=B6rg=20Thalheim?= <joerg@thalheim.io>
+Date: Sat, 14 Oct 2023 11:45:30 +0200
+Subject: [PATCH] allow secrets to be group-readable
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Systemd's LoadCredential feature makes have the following 0o440 permissions.
+Services cannot modify secrets or their permission.
+By relaxing the check we allow buildbot to use secrets provided by systemd.
+
+Signed-off-by: Jörg Thalheim <joerg@thalheim.io>
+---
+ master/buildbot/secrets/providers/file.py        | 2 +-
+ master/buildbot/test/unit/test_secret_in_file.py | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/master/buildbot/secrets/providers/file.py b/master/buildbot/secrets/providers/file.py
+index 11daf327a..293a9f410 100644
+--- a/buildbot/secrets/providers/file.py
++++ b/buildbot/secrets/providers/file.py
+@@ -32,7 +32,7 @@ class SecretInAFile(SecretProviderBase):
+     def checkFileIsReadOnly(self, dirname, secretfile):
+         filepath = os.path.join(dirname, secretfile)
+         obs_stat = stat.S_IMODE(os.stat(filepath).st_mode)
+-        if (obs_stat & 0o77) != 0 and os.name == "posix":
++        if (obs_stat & 0o7) != 0 and os.name == "posix":
+             config.error(f"Permissions {oct(obs_stat)} on file {secretfile} are too open."
+                          " It is required that your secret files are NOT"
+                          " accessible by others!")
+diff --git a/master/buildbot/test/unit/test_secret_in_file.py b/master/buildbot/test/unit/test_secret_in_file.py
+index 01750172d..041b9654f 100644
+--- a/buildbot/test/unit/test_secret_in_file.py
++++ b/buildbot/test/unit/test_secret_in_file.py
+@@ -57,7 +57,7 @@ def testCheckConfigErrorSecretInAFileService(self):
+         if os.name != "posix":
+             self.skipTest("Permission checks only works on posix systems")
+         filepath = self.createFileTemp(self.tmp_dir, "tempfile2.txt",
+-                                       chmodRights=stat.S_IRGRP)
++                                       chmodRights=stat.S_IROTH)
+         expctd_msg_error = " on file tempfile2.txt are too " \
+                            "open. It is required that your secret files are" \
+                            " NOT accessible by others!"
+-- 
+2.42.0
+

--- a/nix/checks/master.nix
+++ b/nix/checks/master.nix
@@ -2,18 +2,22 @@
   name = "from-nixos";
   nodes = {
     # `self` here is set by using specialArgs in `lib.nix`
-    node1 = { self, ... }: {
+    node1 = { self, pkgs, ... }: {
       imports = [
         self.nixosModules.buildbot-master
       ];
       services.buildbot-nix.master = {
         enable = true;
         domain = "buildbot2.thalheim.io";
-        workersFile = "/var/lib/secrets/buildbot-nix/workers.json";
+        workersFile = pkgs.writeText "workers.json" ''
+          [
+            { "name": "eve", "pass": "XXXXXXXXXXXXXXXXXXXX", "cores": 16 }
+          ]
+        '';
         github = {
-          tokenFile = "/var/lib/secrets/buildbot-nix/github-token";
-          webhookSecretFile = "/var/lib/secrets/buildbot-nix/github-webhook-secret";
-          oauthSecretFile = "/var/lib/secrets/buildbot-nix/github-oauth-secret";
+          tokenFile = pkgs.writeText "github-token" "ghp_000000000000000000000000000000000000";
+          webhookSecretFile = pkgs.writeText "webhookSecret" "00000000000000000000";
+          oauthSecretFile = pkgs.writeText "oauthSecret" "ffffffffffffffffffffffffffffffffffffffff";
           oauthId = "aaaaaaaaaaaaaaaaaaaa";
           user = "mic92-buildbot";
           admins = [ "Mic92" ];

--- a/nix/master.nix
+++ b/nix/master.nix
@@ -130,6 +130,7 @@ in
         ps.treq
         ps.psycopg2
         (ps.toPythonModule pkgs.buildbot-worker)
+        ps.setuptools
         pkgs.buildbot-plugins.www
         pkgs.buildbot-plugins.www-react
         pkgs.buildbot-plugins.console-view

--- a/nix/master.nix
+++ b/nix/master.nix
@@ -122,6 +122,9 @@ in
         in
         "${if hasSSL then "https" else "http"}://${cfg.domain}/";
       dbUrl = config.services.buildbot-nix.master.dbUrl;
+      package = (pkgs.buildbot.overrideAttrs (old: {
+        patches = old.patches ++ [ ./0001-allow-secrets-to-be-group-readable.patch ];
+      }));
       pythonPackages = ps: [
         ps.requests
         ps.treq
@@ -129,6 +132,11 @@ in
         (ps.toPythonModule pkgs.buildbot-worker)
         pkgs.buildbot-plugins.www
         pkgs.buildbot-plugins.www-react
+        pkgs.buildbot-plugins.console-view
+        pkgs.buildbot-plugins.waterfall-view
+        pkgs.buildbot-plugins.grid-view
+        pkgs.buildbot-plugins.wsgi-dashboards
+        pkgs.buildbot-plugins.badges
       ];
     };
 

--- a/nix/worker.nix
+++ b/nix/worker.nix
@@ -25,7 +25,7 @@ in
         description = "The buildbot master url.";
       };
       workerPasswordFile = lib.mkOption {
-        type = lib.types.str;
+        type = lib.types.path;
         description = "The buildbot worker password file.";
       };
     };


### PR DESCRIPTION
This fixes force push where github doesn't return the latest ref although the webhook event is already fired.