### PR TITLE
worker: remove `allowed-users`

### DIFF
--- a/nix/worker.nix
+++ b/nix/worker.nix
@@ -31,7 +31,6 @@ in
     };
   };
   config = lib.mkIf cfg.enable {
-    nix.settings.allowed-users = [ "buildbot-worker" ];
     users.users.buildbot-worker = {
       description = "Buildbot Worker User.";
       isSystemUser = true;


### PR DESCRIPTION
The nix default for `allowed-users` is `*` so either need to remove this or change it to `extra-allowed-users`.

Or is this meant to be `trusted-users`?