### PR TITLE
remove extra slash from webhook url

### DIFF
--- a/buildbot_nix/__init__.py
+++ b/buildbot_nix/__init__.py
@@ -721,7 +721,7 @@ class NixConfigurator(ConfiguratorBase):
                 project.owner,
                 project.repo,
                 self.github.token(),
-                f"{self.url}/change_hook/github",
+                self.url + "change_hook/github",
                 webhook_secret,
             )
 


### PR DESCRIPTION
```
https://buildbot.nix-community.org//change_hook/github
```

Noticed this when I checked the webook that was created in `nix-community/infra`.