### PR TITLE
fix project name interpolation for manual builds

### DIFF
--- a/buildbot_nix/__init__.py
+++ b/buildbot_nix/__init__.py
@@ -421,7 +421,7 @@ def nix_eval_config(
     factory = util.BuildFactory()
     # check out the source
     url_with_secret = util.Interpolate(
-        f"https://git:%(secret:{github_token_secret})s@github.com/%(prop:project)s"
+        f"https://git:%(secret:{github_token_secret})s@github.com/{project.name}"
     )
     factory.addStep(
         steps.Git(


### PR DESCRIPTION
The project property seems only to be set by the webhook, it's undefined on manually triggered builds for me (and @aciceri who reminded me to push this now)