### PR TITLE
prefix scheduler names with `project.id`

### DIFF
--- a/buildbot_nix/__init__.py
+++ b/buildbot_nix/__init__.py
@@ -599,7 +599,7 @@ def config_for_project(
     config["schedulers"].extend(
         [
             schedulers.SingleBranchScheduler(
-                name=f"default-branch-{project.id}",
+                name=f"{project.id}-default-branch",
                 change_filter=util.ChangeFilter(
                     repository=project.url,
                     filter_fn=lambda c: c.branch
@@ -610,7 +610,7 @@ def config_for_project(
             ),
             # this is compatible with bors or github's merge queue
             schedulers.SingleBranchScheduler(
-                name=f"merge-queue-{project.id}",
+                name=f"{project.id}-merge-queue",
                 change_filter=util.ChangeFilter(
                     repository=project.url,
                     branch_re="(gh-readonly-queue/.*|staging|trying)",
@@ -619,7 +619,7 @@ def config_for_project(
             ),
             # build all pull requests
             schedulers.SingleBranchScheduler(
-                name=f"prs-{project.id}",
+                name=f"{project.id}-prs",
                 change_filter=util.ChangeFilter(
                     repository=project.url, category="pull"
                 ),


### PR DESCRIPTION
Also prefixed `reload-github-projects` to make it look like `__Janitor` as it is a internal job not specific to a repo.
___
Wasn't sure if should change this or not, I don't think it is visible on buildbot?
https://github.com/Mic92/buildbot-nix/blob/4d71870239d6df8e1b92a1ecbc94a3e671ae462a/buildbot_nix/__init__.py#L68-L69