### PR TITLE
only refresh github projects in timer and sort them

### DIFF
--- a/buildbot_nix/github_projects.py
+++ b/buildbot_nix/github_projects.py
@@ -186,7 +186,9 @@ def refresh_projects(github_token: str, repo_cache_file: Path) -> None:
 
 def load_projects(github_token: str, repo_cache_file: Path) -> list[GithubProject]:
     if not repo_cache_file.exists():
-        log.msg("fetching github repositories")
-        refresh_projects(github_token, repo_cache_file)
-    repos: list[dict[str, Any]] = json.loads(repo_cache_file.read_text())
+        return []
+
+    repos: list[dict[str, Any]] = sorted(
+        json.loads(repo_cache_file.read_text()), key=lambda x: x["full_name"]
+    )
     return [GithubProject(repo) for repo in repos]


### PR DESCRIPTION
This way errors are more visible to users on the first running.