### PR TITLE
master: Add config to force https for the endpoint

### DIFF
--- a/examples/master.nix
+++ b/examples/master.nix
@@ -69,4 +69,8 @@
   #  forceSSL = true;
   #  enableACME = true;
   #};
+
+  # Optional: If buildbot is setup to run behind another proxy that does TLS
+  # termination set this to true to have buildbot use https:// for its endpoint
+  #useHTTPS = true;
 }

--- a/nix/master.nix
+++ b/nix/master.nix
@@ -187,6 +187,14 @@ in
         example = "https://buildbot-webhooks.numtide.com/";
         default = config.services.buildbot-master.buildbotUrl;
       };
+      useHTTPS = lib.mkOption {
+        type = lib.types.nullOr lib.types.bool;
+        default = false;
+        description = ''
+          If buildbot is setup behind a reverse proxy other than the configured nginx set this to true
+          to force the endpoint to use https:// instead of http://.
+        '';
+      };
 
       outputsPath = lib.mkOption {
         type = lib.types.nullOr lib.types.path;
@@ -292,7 +300,7 @@ in
       buildbotUrl =
         let
           host = config.services.nginx.virtualHosts.${cfg.domain};
-          hasSSL = host.forceSSL || host.addSSL;
+          hasSSL = host.forceSSL || host.addSSL || cfg.useHTTPS;
         in
         "${if hasSSL then "https" else "http"}://${cfg.domain}/";
       dbUrl = config.services.buildbot-nix.master.dbUrl;


### PR DESCRIPTION
Let me preface this by saying I'm new to Nix, so sorry if I've missed something obvious and there's another way around this. Also, thank you for your work on this module!

I'm setting up  a buildbot instance using buildbot-nix and I ran into a usecase that isn't currently handled by the module. My buildbot is behind a third party proxy that does TLS termination for me, so I don't need nginx to create or serve any certificates, but there's no way to let the module know that the endpoint must start with `https://` because this is currently tied to the nginx configuration. This patch adds a config option to make the endpoint use `https://` even if it's not setup in nginx.