### PR TITLE
master: on-failure -> always

### DIFF
--- a/nix/master.nix
+++ b/nix/master.nix
@@ -348,7 +348,7 @@ in
 
         # Needed because it tries to reach out to github on boot.
         # FIXME: if github is not available, we shouldn't fail buildbot, instead it should just try later again in the background
-        Restart = "on-failure";
+        Restart = "always";
         RestartSec = "30s";
       };
     };


### PR DESCRIPTION
https://github.com/nix-community/infra/pull/1235#discussion_r1590512432

Seems this needs to be always instead of on-failure as the service exits successfully.

